### PR TITLE
doc: remove shell command $ for copy quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ export async function post(name: string) {
 Please install `@midwayjs/cli` first.
 
 ```bash
-$ npm i @midwayjs/cli -g
+npm i @midwayjs/cli -g
 ```
 
 ### Create
@@ -105,19 +105,19 @@ mw new my-app
 ### Run
 
 ```bash
-$ npm run dev
+npm run dev
 ```
 
 ### Deploy to custom server
 
 ```bash
-$ node bootstrap.js
+node bootstrap.js
 ```
 
 ### Deploy to Serverless
 
 ```bash
-$ npm run deploy
+npm run deploy
 ```
 
 ## Contribute
@@ -133,25 +133,25 @@ We use yarn + lerna to manage the project.
 - install dependencies
 
 ```bash
-$ yarn
+yarn
 ```
 
 - build
 
 ```bash
-$ yarn build
+yarn build
 ```
 
 - watch
 
 ```bash
-$ yarn watch
+yarn watch
 ```
 
 - test
 
 ```bash
-$ yarn test
+yarn test
 ```
 
 ## license

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -91,7 +91,7 @@ export async function post(name: string) {
 请先安装 @midwayjs/cli
 
 ```bash
-$ npm i @midwayjs/cli -g
+npm i @midwayjs/cli -g
 ```
 
 ### 创建
@@ -103,19 +103,19 @@ mw new my-app
 ### 运行
 
 ```bash
-$ npm run dev
+npm run dev
 ```
 
 ### 部署至服务器
 
 ```bash
-$ node bootstrap.js
+node bootstrap.js
 ```
 
 ### 部署至 Serverless
 
 ```bash
-$ npm run deploy
+npm run deploy
 ```
 
 ## Contribute
@@ -131,25 +131,25 @@ $ npm run deploy
 - install dependencies
 
 ```bash
-$ yarn
+yarn
 ```
 
 - build
 
 ```bash
-$ yarn build
+yarn build
 ```
 
 - watch
 
 ```bash
-$ yarn watch
+yarn watch
 ```
 
 - test
 
 ```bash
-$ yarn test
+yarn test
 ```
 
 ## 开源协议


### PR DESCRIPTION
### 修改原因 

使用 github 网页快捷操作复制命令的时候，发现多了一个 $ 符号，导致无法执行命令行。

而且也有不一致的地方。

![image](https://user-images.githubusercontent.com/14177215/142582216-7428b049-3904-4826-9e5b-7140719acb68.png)

查看别的开源项目，比如 facebook cra 项目，也没有 $  符号。

所以提了这个 pull request 。