### PR TITLE
feat: export HooksValidationError

### DIFF
--- a/packages/hooks/src/api/operator/validate.ts
+++ b/packages/hooks/src/api/operator/validate.ts
@@ -6,7 +6,7 @@ const HooksValidateErrorCode = registerErrorCode('Validation', {
   FAILED: 'FAILED',
 })
 
-class HooksValidationError extends MidwayHttpError {
+export class HooksValidationError extends MidwayHttpError {
   constructor(message: string, status: number, cause: any) {
     super(message, status, HooksValidateErrorCode.FAILED, { cause })
   }


### PR DESCRIPTION
export HooksValidationError 供外部使用，可以用于全局错误的捕获