### PR TITLE
fix: use Object.assign instead of `...` operator due to iOS <= 11.3 compatibility issues

### DIFF
--- a/packages/hooks-core/package.json
+++ b/packages/hooks-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@midwayjs/hooks-core",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Midway Hooks Core",
   "keywords": [
     "midway",

--- a/packages/hooks-core/src/request/index.ts
+++ b/packages/hooks-core/src/request/index.ts
@@ -6,11 +6,8 @@ export type { ApiParam, ApiHttpMethod } from '../types/http'
 
 export const defaults = {
   async request(param: ApiParam) {
-    const response = await axios({
-      baseURL: defaults.baseURL,
-      ...param,
-    })
-
+    const requestConfig = Object.assign({ baseURL: defaults.baseURL }, param)
+    const response = await axios(requestConfig)
     return response?.data
   },
   baseURL: '',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13161470/198542761-785a2bce-2b07-4f90-81cc-cd0280e6038b.png)
